### PR TITLE
Updating build to include JavaDocs and sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
 after_success:
 - mvn package bundle:bundle
-- mvn deploy:deploy-file -Dfile=target/library-1.1-SNAPSHOT.jar -Durl=https://oss.sonatype.org/content/repositories/snapshots -DrepositoryId=ossrh -DpomFile=pom.xml --settings travis-settings.xml -DskipTests=true -B
+- mvn deploy:deploy-file -Dfile=target/library-1.1-SNAPSHOT.jar -Djavadoc=target/library-1.1-SNAPSHOT-javadoc.jar -Dsources=target/library-1.1-SNAPSHOT-sources.jar -Durl=https://oss.sonatype.org/content/repositories/snapshots -DrepositoryId=ossrh -DpomFile=pom.xml --settings travis-settings.xml -DskipTests=true -B
 - bash <(curl -s https://codecov.io/bash)
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk>1.8</jdk>
     <maven.compiler.version>3.8.1</maven.compiler.version>
+    <maven.javadoc.version>3.2.0</maven.javadoc.version>
+    <maven.source.version>3.2.1</maven.source.version>
     <maven.bundle.compiler.version>4.2.1</maven.bundle.compiler.version>
     <micrometer.version>1.0.8</micrometer.version>
     <siddhi.version>5.1.2</siddhi.version>
@@ -268,6 +270,36 @@
                 <source>${jdk}</source>
                 <target>${jdk}</target>
             </configuration>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven.javadoc.version}</version>
+            <executions>
+                <execution>
+                    <id>attach-javadocs</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven.source.version}</version>
+            <executions>
+                <execution>
+                    <id>attach-sources</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>jar-no-fork</goal>
+                    </goals>
+                </execution>
+            </executions>
         </plugin>
 
         <plugin>

--- a/src/main/java/io/cresco/library/messaging/RPC.java
+++ b/src/main/java/io/cresco/library/messaging/RPC.java
@@ -43,6 +43,7 @@ public class RPC {
     /**
      * Issues a remote procedure call
      * @param msg           Message to send
+     * @param timeout       How long to wait for the response (in milliseconds)
      * @return              The return message, null if no return is received
      */
     public MsgEvent call(MsgEvent msg, long timeout) {


### PR DESCRIPTION
- Added JavaDoc and sources build on package
- Updated Travis push to include JavaDocs and sources
- Filled in missing RPC call parameter from JavaDoc warning